### PR TITLE
Update totals header with state info

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <div class="content">
             <div id="results" class="left-panel"></div>
             <div class="right-panel">
-                <h2>Totals</h2>
+                <h2 id="totalsHeader">Totals</h2>
                 <p id="totalViolations">Total Violations: 0</p>
                 <p id="totalAmountDue">Total Amount Due: $0</p>
                 <p id="totalPaymentAmount">Total Payment Amount: $0</p>


### PR DESCRIPTION
## Summary
- show totals for the queried plate in the UI header
- keep plate and state in local storage so sorting preserves the header
- reset header when clearing totals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684098c58438832db50dfa224e4db824